### PR TITLE
Fixing missing protocol in the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Changelog
+
+### Changed
+- `mino.Address` with `https` protocol also needs the port-#
+
+### Deprecated
+### Removed
+### Fixed
+- representation of `mino.Address` now always has the protocol
+
+### Security

--- a/cli/node/memcoin/mod_test.go
+++ b/cli/node/memcoin/mod_test.go
@@ -102,7 +102,7 @@ func TestMemcoin_Scenario_SetupAndTransactions(t *testing.T) {
 	// Run a few transactions.
 	for i := 0; i < 5; i++ {
 		err = runWithCfg(args, config{})
-		require.EqualError(t, err, "command error: transaction refused: duplicate in roster: 127.0.0.1:2115")
+		require.EqualError(t, err, "command error: transaction refused: duplicate in roster: grpcs://127.0.0.1:2115")
 	}
 
 	// Test a timeout waiting for a transaction.
@@ -158,7 +158,7 @@ func TestMemcoin_Scenario_RestartNode(t *testing.T) {
 	)
 
 	err = run(args)
-	require.EqualError(t, err, "command error: transaction refused: duplicate in roster: 127.0.0.1:2210")
+	require.EqualError(t, err, "command error: transaction refused: duplicate in roster: grpcs://127.0.0.1:2210")
 }
 
 // -----------------------------------------------------------------------------

--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -26,7 +26,7 @@ func TestMinogrpc_New(t *testing.T) {
 	m, err := NewMinogrpc(addr, nil, router)
 	require.NoError(t, err)
 
-	require.Equal(t, "127.0.0.1:3333", m.GetAddress().String())
+	require.Equal(t, "grpcs://127.0.0.1:3333", m.GetAddress().String())
 	require.Empty(t, m.segments)
 
 	cert := m.GetCertificateChain()
@@ -44,7 +44,7 @@ func TestMinogrpc_noTLS(t *testing.T) {
 	m, err := NewMinogrpc(addr, nil, router, NoTLS())
 	require.NoError(t, err)
 
-	require.Equal(t, "127.0.0.1:3333", m.GetAddress().String())
+	require.Equal(t, "grpcs://127.0.0.1:3333", m.GetAddress().String())
 	require.Empty(t, m.segments)
 
 	cert, err := m.certs.Load(m.GetAddress())
@@ -273,7 +273,7 @@ func TestMinogrpc_String(t *testing.T) {
 		overlay: &overlay{myAddr: session.Address{}},
 	}
 
-	require.Equal(t, "mino[]", minoGrpc.String())
+	require.Equal(t, "mino[grpc://]", minoGrpc.String())
 }
 
 func TestMinogrpc_DecorateTrace_NoFound(t *testing.T) {

--- a/mino/minogrpc/server_test.go
+++ b/mino/minogrpc/server_test.go
@@ -925,7 +925,7 @@ func TestConnManager_MissingCert_Acquire(t *testing.T) {
 
 	to := session.NewAddress("fake")
 	_, err := mgr.Acquire(to)
-	require.EqualError(t, err, "failed to retrieve transport credential: certificate for 'fake' not found")
+	require.EqualError(t, err, "failed to retrieve transport credential: certificate for 'grpcs://fake' not found")
 }
 
 func TestConnManager_FailLoadOwnCert_Acquire(t *testing.T) {
@@ -1024,8 +1024,10 @@ func TestConnManager_BadTracer_Acquire(t *testing.T) {
 
 	dstAddr := dst.GetAddress()
 	_, err = mgr.Acquire(dstAddr)
+	dialAddr := strings.Split(dst.GetAddress().String(), "://")
+	require.Equal(t, 2, len(dialAddr))
 	require.EqualError(t, err, fmt.Sprintf("failed to get tracer for addr %s: %s",
-		dst.GetAddress(), fake.GetError().Error()))
+		dialAddr[1], fake.GetError().Error()))
 
 	getTracerForAddr = tracing.GetTracerForAddr
 }

--- a/mino/minogrpc/session/addr_test.go
+++ b/mino/minogrpc/session/addr_test.go
@@ -65,10 +65,9 @@ func TestAddress_MarshalText(t *testing.T) {
 
 func TestAddress_String(t *testing.T) {
 	addr := NewAddress("127.0.0.1:2000")
-	require.Equal(t, addr.host, addr.String())
 
 	orch := NewOrchestratorAddress(addr)
-	require.Equal(t, "Orchestrator:"+addr.host, orch.String())
+	require.Equal(t, "Orchestrator:"+addr.String(), orch.String())
 }
 
 func TestWrapAddress_Unwrap(t *testing.T) {

--- a/mino/router/tree/example_test.go
+++ b/mino/router/tree/example_test.go
@@ -28,7 +28,7 @@ func ExampleRouter_New() {
 	}
 
 	// Output: map[]
-	// 127.0.0.1:3000
+	// grpcs://127.0.0.1:3000
 }
 
 func ExampleTable_PrepareHandshakeFor() {
@@ -60,6 +60,6 @@ func ExampleTable_PrepareHandshakeFor() {
 	fmt.Println(packet.GetSource())
 	fmt.Println(packet.GetDestination())
 
-	// Output: 127.0.0.1:3000
-	// [127.0.0.1:2000]
+	// Output: grpcs://127.0.0.1:3000
+	// [grpcs://127.0.0.1:2000]
 }

--- a/test/cosidela_test.go
+++ b/test/cosidela_test.go
@@ -198,7 +198,7 @@ func (c cosiDelaNode) Setup(delas ...dela) {
 	joinable, ok := c.onet.(minogrpc.Joinable)
 	require.True(c.t, ok)
 
-	addrURL, err := url.Parse("//" + c.onet.GetAddress().String())
+	addrURL, err := url.Parse(c.onet.GetAddress().String())
 	require.NoError(c.t, err, addrURL)
 
 	token := joinable.GenerateToken(time.Hour)


### PR DESCRIPTION
With the changes in fix-notls, the protocol becomes part of the node-ID, because it is needed to make the correct connection and verify or not the certificate.

This change makes sure that the full name is used wherever necessary, and makes the tests pass again.

There might still be things lingering which are not happy with the new node-ID.

Locally the tests with 'run_local.sh' pass.