### PR TITLE
Adding a fast synchronisation protocol

### DIFF
--- a/core/ordering/cosipbft/fastsync/default.go
+++ b/core/ordering/cosipbft/fastsync/default.go
@@ -1,0 +1,316 @@
+package fastsync
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.dedis.ch/dela"
+	"go.dedis.ch/dela/core/ordering/cosipbft/blockstore"
+	"go.dedis.ch/dela/core/ordering/cosipbft/blocksync"
+	"go.dedis.ch/dela/core/ordering/cosipbft/fastsync/types"
+	"go.dedis.ch/dela/core/ordering/cosipbft/pbft"
+	otypes "go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/crypto"
+	"go.dedis.ch/dela/internal/tracing"
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/serde/json"
+	"golang.org/x/xerrors"
+)
+
+var timeoutSync = 20 * time.Second
+var protocolName = "fastsync"
+
+// fastSync is a block synchronizer which quickly catches up to the
+// latest block.
+//
+// - implements fastsync.Synchronizer
+type fastSync struct {
+	logger zerolog.Logger
+	rpc    mino.RPC
+	pbftsm pbft.StateMachine
+	blocks blockstore.BlockStore
+
+	Mino mino.Mino
+
+	latest      *uint64
+	catchUpLock *sync.Mutex
+
+	// This is for debugging
+	syncMessages *int
+}
+
+// NewSynchronizer creates a new block synchronizer.
+func NewSynchronizer(param blocksync.SyncParam) Synchronizer {
+	latest := param.Blocks.Len()
+
+	logger := dela.Logger.With().Str("addr", param.Mino.GetAddress().String()).Logger()
+
+	h := &handler{
+		latest:      &latest,
+		catchUpLock: new(sync.Mutex),
+		logger:      logger,
+		genesis:     param.Genesis,
+		blocks:      param.Blocks,
+		pbftsm:      param.PBFT,
+		verifierFac: param.VerifierFactory,
+	}
+
+	fac := types.NewMessageFactory(param.LinkFactory)
+
+	s := fastSync{
+		logger:      logger,
+		rpc:         mino.MustCreateRPC(param.Mino, "fastsync", h, fac),
+		pbftsm:      param.PBFT,
+		blocks:      param.Blocks,
+		latest:      &latest,
+		catchUpLock: h.catchUpLock,
+		Mino:        param.Mino,
+	}
+
+	return s
+}
+
+// Sync implements fastsync.Synchronizer.
+// It asks the other nodes what their latest block is, and then chooses some
+// nodes randomly to request catching up the missing blocks.
+func (s fastSync) Sync(ctx context.Context, players mino.Players, config Config) error {
+	if players.Len() == 0 {
+		return xerrors.Errorf("need at least 1 node to contact")
+	}
+	ctx = context.WithValue(ctx, tracing.ProtocolKey, protocolName)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeoutSync))
+	defer cancel()
+
+	// Make sure that the address of this node is at the beginning of the list.
+	addresses := []mino.Address{s.Mino.GetAddress()}
+	for iter := players.AddressIterator(); iter.HasNext(); {
+		addr := iter.GetNext()
+		if !s.Mino.GetAddress().Equal(addr) {
+			addresses = append(addresses, addr)
+		}
+	}
+	players = mino.NewAddresses(addresses...)
+	sender, rcvr, err := s.rpc.Stream(ctx, players)
+	if err != nil {
+		return xerrors.Errorf("stream failed: %v", err)
+	}
+
+	// Send a catchup-request to f+1 nodes with our latest known block,
+	// but not to this node.
+	// This should be enough, because the protocol supposes there are only
+	// f byzantine nodes, so this should contact at least one healthy node.
+	f := (players.Len() - 1) / 3
+	nodes := players.Take(mino.RangeFilter(1, players.Len()),
+		mino.RandomFilter(f+1))
+
+	// Send the request as many times as needed, because with a
+	// SplitMessageSize < size(all missing blocks), multiple requests are
+	// needed.
+	blockCount := s.blocks.Len()
+	for {
+		more, err := s.requestSync(ctx, sender, rcvr, nodes, config.SplitMessageSize)
+		if err != nil {
+			return xerrors.Errorf("error while requesting sync updates: %v", err)
+		}
+		if s.syncMessages != nil {
+			*s.syncMessages += 1
+		}
+
+		if !more {
+			break
+		} else if blockCount == s.blocks.Len() {
+			s.logger.Warn().Msgf("one of the nodes returned it has more blocks, "+
+				"but didn't deliver: %v", nodes)
+			break
+		}
+
+		blockCount = s.blocks.Len()
+	}
+
+	return nil
+}
+
+// requestSync asks all 'nodes' to send their block updates.
+// The return is a boolean indicating whether at least one node indicated
+// there are more blocks.
+// This might be wrong, as there is no check whether the sending node is
+// byzantine or not.
+func (s fastSync) requestSync(
+	ctx context.Context,
+	sender mino.Sender,
+	rcvr mino.Receiver,
+	nodes mino.Players,
+	sms uint64,
+) (bool, error) {
+	// Send the messages to all nodes
+	s.logger.Debug().Msgf("Sending catchup req to %+v", nodes)
+	errs := sender.Send(types.NewRequestCatchupMessage(sms, s.blocks.Len()),
+		iter2arr(nodes.AddressIterator())...)
+	errCount := 0
+	for err := range errs {
+		errCount += 1
+		if err != nil {
+			s.logger.Warn().Err(err).Msgf("announcement failed to one node")
+		}
+	}
+	if errCount == nodes.Len() {
+		return false, xerrors.Errorf("contacted %d nodes, but all failed: %v", len(errs), errs)
+	}
+
+	// Wait for all replies, supposing that there are no more than f nodes
+	// not replying or replying with wrong blocks.
+
+	replies := make(map[string]struct{})
+	moreBlocks := false
+	for len(replies) < nodes.Len() {
+		s.logger.Debug().Msgf("Waiting for replies: %d < %d", len(replies), nodes.Len())
+		from, msg, err := rcvr.Recv(ctx)
+		if err == context.Canceled || err == context.DeadlineExceeded || err == io.EOF {
+			return moreBlocks, nil
+		}
+		if err != nil {
+			s.logger.Debug().Err(err).Msg("sync finished with error")
+			return false, nil
+		}
+
+		_, received := replies[from.String()]
+		if received {
+			s.logger.Warn().Msgf("received two fastsync messages from %s", from)
+			continue
+		}
+
+		catchup, ok := msg.(types.CatchupMessage)
+		if ok {
+			s.logger.Trace().Msgf("Got %d blocks from %v",
+				len(catchup.GetBlockLinks()), from)
+
+			replies[from.String()] = struct{}{}
+			moreBlocks = moreBlocks || catchup.GetSplitMessage()
+
+			for _, bl := range catchup.GetBlockLinks() {
+				if bl.GetBlock().GetIndex() >= s.blocks.Len() {
+					err := s.pbftsm.CatchUp(bl)
+					if err != nil {
+						s.logger.Warn().Err(err).Msg("while using block to catchup")
+					}
+				}
+			}
+		}
+	}
+
+	return moreBlocks, nil
+}
+
+// handler is a Mino handler for the synchronization messages.
+//
+// - implements mino.Handler
+type handler struct {
+	mino.UnsupportedHandler
+
+	latest      *uint64
+	catchUpLock *sync.Mutex
+
+	logger      zerolog.Logger
+	blocks      blockstore.BlockStore
+	genesis     blockstore.GenesisStore
+	pbftsm      pbft.StateMachine
+	verifierFac crypto.VerifierFactory
+}
+
+// Stream implements mino.Handler. It waits for a request message and then
+// replies with eventually missing BlockLinks of the requester.
+func (h *handler) Stream(out mino.Sender, in mino.Receiver) error {
+	h.logger.Debug().Msg("Starting stream")
+	ctx := context.Background()
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeoutSync))
+	defer cancel()
+
+	for sentAllBlocks := false; !sentAllBlocks; {
+		m, orch, err := h.waitRequest(ctx, in)
+		if err != nil {
+			return xerrors.Errorf("no request: %v", err)
+		}
+
+		blReply, err := h.getBlocks(m)
+		if err != nil {
+			return xerrors.Errorf("creating blocks to send failed: %v", err)
+		}
+
+		sentAllBlocks = m.GetLatest()+uint64(len(blReply)) == h.blocks.Len()
+		err = <-out.Send(types.NewCatchupMessage(
+			!sentAllBlocks, blReply), orch)
+		if err != nil {
+			return xerrors.Errorf("sending request failed: %v", err)
+		}
+	}
+
+	h.logger.Debug().Msg("done sending catchup blocks")
+
+	return nil
+}
+
+// getBlocks creates a reply that will only overflow the given message-size
+// budget by at most one block.
+func (h *handler) getBlocks(m *types.RequestCatchupMessage) ([]otypes.BlockLink, error) {
+	var blReply []otypes.BlockLink
+
+	msgSize := uint64(0)
+	if h.blocks.Len() > m.GetLatest() {
+		for index := m.GetLatest(); index < h.blocks.Len(); index++ {
+			bl, err := h.blocks.GetByIndex(index)
+			if err != nil {
+				return blReply, xerrors.Errorf("failed to get block with index %d", index)
+			}
+			blReply = append(blReply, bl)
+			b, err := bl.Serialize(json.NewContext())
+			if err != nil {
+				return blReply, xerrors.Errorf("failed to serialize block %d: %v", index, err)
+			}
+			msgSize += uint64(len(b))
+
+			if m.GetSplitMessageSize() > 0 && msgSize >= m.GetSplitMessageSize() {
+				h.logger.Debug().Msgf("splitting message because size %d >= %d",
+					msgSize, m.GetSplitMessageSize())
+				break
+			}
+		}
+		h.logger.Debug().Msgf("Sending blocks %d..%d", m.GetLatest(),
+			m.GetLatest()+uint64(len(blReply))-1)
+	} else {
+		h.logger.Debug().Msgf("No new blocks to send")
+	}
+
+	return blReply, nil
+}
+
+func (h *handler) waitRequest(
+	ctx context.Context,
+	in mino.Receiver,
+) (*types.RequestCatchupMessage, mino.Address, error) {
+
+	for {
+		orch, msg, err := in.Recv(ctx)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("receiver failed: %v", err)
+		}
+
+		// The SyncMessage contains the chain to the latest block known by the
+		// leader which allows to verify if it is not lying.
+		m, ok := msg.(types.RequestCatchupMessage)
+		if ok {
+			return &m, orch, nil
+		}
+	}
+}
+
+func iter2arr(iter mino.AddressIterator) []mino.Address {
+	var addrs []mino.Address
+	for iter.HasNext() {
+		addrs = append(addrs, iter.GetNext())
+	}
+
+	return addrs
+}

--- a/core/ordering/cosipbft/fastsync/default_test.go
+++ b/core/ordering/cosipbft/fastsync/default_test.go
@@ -1,0 +1,162 @@
+package fastsync
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/ordering/cosipbft/authority"
+	"go.dedis.ch/dela/core/ordering/cosipbft/blockstore"
+	"go.dedis.ch/dela/core/ordering/cosipbft/blocksync"
+	"go.dedis.ch/dela/core/ordering/cosipbft/pbft"
+	otypes "go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/core/txn/signed"
+	"go.dedis.ch/dela/core/validation/simple"
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/minoch"
+	"go.dedis.ch/dela/testing/fake"
+)
+
+func TestDefaultSync_Basic(t *testing.T) {
+	n := 20
+	f := (n - 1) / 3
+	num := 10
+
+	syncs, genesis, roster := makeNodes(t, n)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := syncs[0].Sync(ctx, roster, Config{SplitMessageSize: 1})
+	require.NoError(t, err)
+
+	storeBlocks(t, syncs[0].blocks, num, genesis.GetHash().Bytes()...)
+
+	// Test only a subset of the roster to prepare for the next test.
+	for node := 1; node < n; node++ {
+		// Send the sync call to the leader
+		contact := roster.Take(mino.IndexFilter(0))
+		if node >= 2*f+1 {
+			// Now that there are 2f+1 nodes with the block, sync with
+			// the whole roster.
+			contact = roster
+		}
+		err = syncs[node].Sync(ctx, contact, Config{})
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < n; i++ {
+		require.Equal(t, uint64(num), syncs[i].blocks.Len(), strconv.Itoa(i))
+	}
+}
+
+func TestDefaultSync_SplitMessage(t *testing.T) {
+	num := 10
+
+	tests := []struct {
+		sms  uint64
+		msgs int
+	}{
+		{0, 1},
+		{1, 10},
+		{255, 10},
+		{256, 5},
+		{1024, 2},
+		{2550, 1},
+	}
+	for _, test := range tests {
+		syncs, genesis, roster := makeNodes(t, 2)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		storeBlocks(t, syncs[0].blocks, num, genesis.GetHash().Bytes()...)
+
+		syncsReceived := 0
+		syncs[1].syncMessages = &syncsReceived
+		err := syncs[1].Sync(ctx, roster, Config{SplitMessageSize: test.sms})
+		require.NoError(t, err)
+		require.Equal(t, test.msgs, syncsReceived)
+		require.Equal(t, uint64(num), syncs[1].blocks.Len())
+		cancel()
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+func makeNodes(t *testing.T, n int) ([]fastSync, otypes.Genesis, mino.Players) {
+	manager := minoch.NewManager()
+
+	syncs := make([]fastSync, n)
+	addrs := make([]mino.Address, n)
+
+	ro := authority.FromAuthority(fake.NewAuthority(3, fake.NewSigner))
+
+	genesis, err := otypes.NewGenesis(ro)
+	require.NoError(t, err)
+
+	for i := 0; i < n; i++ {
+		m := minoch.MustCreate(manager, fmt.Sprintf("node%d", i))
+
+		addrs[i] = m.GetAddress()
+
+		genstore := blockstore.NewGenesisStore()
+		require.NoError(t, genstore.Set(genesis))
+
+		blocks := blockstore.NewInMemory()
+		blockFac := otypes.NewBlockFactory(simple.NewResultFactory(signed.NewTransactionFactory()))
+		csFac := authority.NewChangeSetFactory(m.GetAddressFactory(), fake.PublicKeyFactory{})
+		linkFac := otypes.NewLinkFactory(blockFac, fake.SignatureFactory{}, csFac)
+
+		param := blocksync.SyncParam{
+			Mino:            m,
+			Blocks:          blocks,
+			Genesis:         genstore,
+			LinkFactory:     linkFac,
+			ChainFactory:    otypes.NewChainFactory(linkFac),
+			PBFT:            testSM{blocks: blocks},
+			VerifierFactory: fake.VerifierFactory{},
+		}
+
+		syncs[i] = NewSynchronizer(param).(fastSync)
+	}
+
+	return syncs, genesis, mino.NewAddresses(addrs...)
+}
+
+// Create n new blocks and store them while creating appropriate links.
+func storeBlocks(t *testing.T, blocks blockstore.BlockStore, n int, from ...byte) {
+	prev := otypes.Digest{}
+	copy(prev[:], from)
+
+	for i := 0; i < n; i++ {
+		block, err := otypes.NewBlock(simple.NewResult(nil), otypes.WithIndex(uint64(i)))
+		require.NoError(t, err)
+
+		link, err := otypes.NewBlockLink(prev, block,
+			otypes.WithSignatures(fake.Signature{}, fake.Signature{}))
+		require.NoError(t, err)
+
+		err = blocks.Store(link)
+		require.NoError(t, err)
+
+		prev = block.GetHash()
+	}
+}
+
+type testSM struct {
+	pbft.StateMachine
+
+	blocks blockstore.BlockStore
+}
+
+func (sm testSM) CatchUp(link otypes.BlockLink) error {
+	err := sm.blocks.Store(link)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/core/ordering/cosipbft/fastsync/fastsync.go
+++ b/core/ordering/cosipbft/fastsync/fastsync.go
@@ -1,0 +1,48 @@
+// Package fastsync defines a block synchronizer for the ordering service.
+//
+// The block synchronizer is to be called in two situations:
+// - if a node is starting up, to make sure it's up-to-date with other nodes
+// - if a node receives a request for a block it doesn't hold the parent of
+//
+// To make it really simple, the node sends a catchup request parallel to
+// f+1 random nodes.
+// As long as there are enough honest nodes, this will allow the block to
+// catch up to the latest block.
+// One optimization would be to send the requests serially, waiting for the
+// reply before going on.
+// But this would involve timeouts and would take much longer.
+// So we suppose the node is not that much behind and thus will not waste too
+// much bandwidth.
+//
+// Possible improvements:
+// - make the protocol more efficient in the presence of byzantine nodes:
+// The node broadcasts a request indicating which is the last block in storage.
+// It receives offers from different nodes, and contacts the n nodes with the
+// most recent block, where n must be bigger than the maximum number of
+// byzantine nodes.
+//
+// Documentation Last Review: 22.11.2023
+package fastsync
+
+import (
+	"context"
+
+	"go.dedis.ch/dela/mino"
+)
+
+// Config of the current run of the fastsync.
+// For future expansion and to make it similar to blocksync,
+// this is held as a struct.
+type Config struct {
+	// The size at which the message will be split.
+	// If the encoding of all blocks is bigger than this value, the
+	// message is sent as-is.
+	SplitMessageSize uint64
+}
+
+// Synchronizer is an interface to synchronize a node with the participants.
+type Synchronizer interface {
+	// Sync sends a synchronization request message to f+1 random participants,
+	// which will return BlockLinks to the latest block.
+	Sync(ctx context.Context, players mino.Players, config Config) error
+}

--- a/core/ordering/cosipbft/fastsync/json/json.go
+++ b/core/ordering/cosipbft/fastsync/json/json.go
@@ -1,0 +1,114 @@
+package json
+
+import (
+	"encoding/json"
+
+	"go.dedis.ch/dela/core/ordering/cosipbft/fastsync/types"
+	otypes "go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	types.RegisterMessageFormat(serde.FormatJSON, msgFormat{})
+}
+
+// RequestCatchupMessageJSON is the JSON representation of a request catchup
+// message.
+type RequestCatchupMessageJSON struct {
+	SplitMessageSize uint64
+	Latest           uint64
+}
+
+// CatchupMessageJSON is the JSON representation of all the new BlockLinks.
+type CatchupMessageJSON struct {
+	SplitMessage bool
+	BlockLinks   []json.RawMessage
+}
+
+// MessageJSON is the JSON representation of a sync message.
+type MessageJSON struct {
+	Request *RequestCatchupMessageJSON `json:",omitempty"`
+	Catchup *CatchupMessageJSON        `json:",omitempty"`
+}
+
+// MsgFormat is the format engine to encode and decode sync messages.
+//
+// - implements serde.FormatEngine
+type msgFormat struct{}
+
+// Encode implements serde.FormatEngine. It returns the JSON data of the message
+// if appropriate, otherwise an error.
+func (fmt msgFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) {
+	var m MessageJSON
+
+	switch in := msg.(type) {
+	case types.RequestCatchupMessage:
+		request := RequestCatchupMessageJSON{
+			SplitMessageSize: in.GetSplitMessageSize(),
+			Latest:           in.GetLatest(),
+		}
+
+		m.Request = &request
+	case types.CatchupMessage:
+		bls := in.GetBlockLinks()
+		catchup := CatchupMessageJSON{
+			SplitMessage: in.GetSplitMessage(),
+			BlockLinks:   make([]json.RawMessage, len(bls)),
+		}
+
+		for i, bl := range bls {
+			blBuf, err := bl.Serialize(ctx)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to encode blocklink: %v", err)
+			}
+			catchup.BlockLinks[i] = blBuf
+		}
+
+		m.Catchup = &catchup
+	default:
+		return nil, xerrors.Errorf("unsupported message '%T'", msg)
+	}
+
+	data, err := ctx.Marshal(m)
+	if err != nil {
+		return nil, xerrors.Errorf("marshal failed: %v", err)
+	}
+
+	return data, nil
+}
+
+// Decode implements serde.FormatEngine. It returns the message associated to
+// the data if appropriate, otherwise an error.
+func (fmt msgFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error) {
+	m := MessageJSON{}
+	err := ctx.Unmarshal(data, &m)
+	if err != nil {
+		return nil, xerrors.Errorf("unmarshal failed: %v", err)
+	}
+
+	if m.Request != nil {
+		return types.NewRequestCatchupMessage(m.Request.SplitMessageSize, m.Request.Latest), nil
+	}
+
+	if m.Catchup != nil {
+		fac := ctx.GetFactory(types.LinkKey{})
+
+		factory, ok := fac.(otypes.LinkFactory)
+		if !ok {
+			return nil, xerrors.Errorf("invalid link factory '%T'", fac)
+		}
+
+		var blockLinks = make([]otypes.BlockLink, len(m.Catchup.BlockLinks))
+		for i, blBuf := range m.Catchup.BlockLinks {
+			blockLinks[i], err = factory.BlockLinkOf(ctx, blBuf)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to decode blockLink: %v", err)
+			}
+		}
+
+		return types.NewCatchupMessage(m.Catchup.SplitMessage, blockLinks), nil
+	}
+
+	return nil, xerrors.New("message is empty")
+}

--- a/core/ordering/cosipbft/fastsync/json/json_test.go
+++ b/core/ordering/cosipbft/fastsync/json/json_test.go
@@ -1,0 +1,76 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/ordering/cosipbft/fastsync/types"
+	otypes "go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/testing/fake"
+)
+
+func TestMsgFormat_Encode(t *testing.T) {
+	format := msgFormat{}
+
+	ctx := fake.NewContext()
+
+	data, err := format.Encode(ctx, types.NewCatchupMessage(false, []otypes.BlockLink{fakeLink{}}))
+	require.NoError(t, err)
+	require.Equal(t, `{"Catchup":{"SplitMessage":false,"BlockLinks":[{}]}}`, string(data))
+
+	data, err = format.Encode(ctx, types.NewRequestCatchupMessage(1, 3))
+	require.NoError(t, err)
+	require.Equal(t, `{"Request":{"SplitMessageSize":1,"Latest":3}}`, string(data))
+
+	_, err = format.Encode(ctx, fake.Message{})
+	require.EqualError(t, err, "unsupported message 'fake.Message'")
+
+	_, err = format.Encode(ctx,
+		types.NewCatchupMessage(false, []otypes.BlockLink{fakeLink{err: fake.GetError()}}))
+	require.EqualError(t, err, fake.Err("failed to encode blocklink"))
+}
+
+func TestMsgFormat_Decode(t *testing.T) {
+	format := msgFormat{}
+
+	ctx := fake.NewContext()
+	ctx = serde.WithFactory(ctx, types.LinkKey{}, fakeLinkFac{})
+
+	msg, err := format.Decode(ctx, []byte(`{"Catchup":{"SplitMessage":true,"BlockLinks":[{}]}}`))
+	require.NoError(t, err)
+	require.Equal(t, types.NewCatchupMessage(true, []otypes.BlockLink{fakeLink{}}), msg)
+
+	msg, err = format.Decode(ctx, []byte(`{"Request":{"SplitMessageSize":1,"Latest":3}}`))
+	require.NoError(t, err)
+	require.Equal(t, types.NewRequestCatchupMessage(1, 3), msg)
+
+	_, err = format.Decode(ctx, []byte(`{}`))
+	require.EqualError(t, err, "message is empty")
+
+	_, err = format.Decode(fake.NewBadContext(), []byte(`{}`))
+	require.EqualError(t, err, fake.Err("unmarshal failed"))
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type fakeLink struct {
+	otypes.BlockLink
+
+	err error
+}
+
+func (link fakeLink) Serialize(serde.Context) ([]byte, error) {
+	return []byte("{}"), link.err
+}
+
+type fakeLinkFac struct {
+	otypes.LinkFactory
+
+	err error
+}
+
+func (fac fakeLinkFac) BlockLinkOf(serde.Context, []byte) (otypes.BlockLink, error) {
+	return fakeLink{}, fac.err
+}

--- a/core/ordering/cosipbft/fastsync/types/types.go
+++ b/core/ordering/cosipbft/fastsync/types/types.go
@@ -1,0 +1,118 @@
+package types
+
+import (
+	"go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/serde/registry"
+	"golang.org/x/xerrors"
+)
+
+var msgFormats = registry.NewSimpleRegistry()
+
+// RegisterMessageFormat registers the engine for the given format.
+func RegisterMessageFormat(f serde.Format, e serde.FormatEngine) {
+	msgFormats.Register(f, e)
+}
+
+// RequestCatchupMessage is sent by a node which wants to catch up to the latest
+// block.
+type RequestCatchupMessage struct {
+	splitMessageSize uint64
+	latest           uint64
+}
+
+// NewRequestCatchupMessage creates a RequestCatchupMessage
+func NewRequestCatchupMessage(splitMessageSize, latest uint64) RequestCatchupMessage {
+	return RequestCatchupMessage{splitMessageSize: splitMessageSize, latest: latest}
+}
+
+// GetLatest returns the latest index requested by the sender.
+func (m RequestCatchupMessage) GetLatest() uint64 {
+	return m.latest
+}
+
+// GetSplitMessageSize returns the size at which a message should be split.
+func (m RequestCatchupMessage) GetSplitMessageSize() uint64 {
+	return m.splitMessageSize
+}
+
+// Serialize implements serde.Message. It returns the serialized data for this
+// message.
+func (m RequestCatchupMessage) Serialize(ctx serde.Context) ([]byte, error) {
+	format := msgFormats.Get(ctx.GetFormat())
+
+	data, err := format.Encode(ctx, m)
+	if err != nil {
+		return nil, xerrors.Errorf("encoding failed: %v", err)
+	}
+
+	return data, nil
+}
+
+// CatchupMessage returns all the blocks, not just the links, so that the
+// node can re-create the correct global state.
+// 'splitMessage' is true if the node knows about more nodes.
+type CatchupMessage struct {
+	splitMessage bool
+	blockLinks   []types.BlockLink
+}
+
+// NewCatchupMessage creates a reply to RequestLatestMessage.
+func NewCatchupMessage(splitMessage bool, blockLinks []types.BlockLink) CatchupMessage {
+	return CatchupMessage{splitMessage: splitMessage, blockLinks: blockLinks}
+}
+
+// GetBlockLinks returns the BlockLinks of the catchup.
+func (m CatchupMessage) GetBlockLinks() []types.BlockLink {
+	return m.blockLinks
+}
+
+// GetSplitMessage returns if the sending node has more blocks.
+func (m CatchupMessage) GetSplitMessage() bool {
+	return m.splitMessage
+}
+
+// Serialize implements serde.Message. It returns the serialized data for this
+// message.
+func (m CatchupMessage) Serialize(ctx serde.Context) ([]byte, error) {
+	format := msgFormats.Get(ctx.GetFormat())
+
+	data, err := format.Encode(ctx, m)
+	if err != nil {
+		return nil, xerrors.Errorf("encoding failed: %v", err)
+	}
+
+	return data, nil
+}
+
+// LinkKey is the key of the block link factory.
+type LinkKey struct{}
+
+// MessageFactory is a message factory for sync messages.
+//
+// - implements serde.Factory
+type MessageFactory struct {
+	linkFac types.LinkFactory
+}
+
+// NewMessageFactory creates new message factory.
+func NewMessageFactory(fac types.LinkFactory) MessageFactory {
+	return MessageFactory{
+		linkFac: fac,
+	}
+}
+
+// Deserialize implements serde.Factory. It returns the message associated to
+// the data if appropriate, otherwise an error.
+func (fac MessageFactory) Deserialize(ctx serde.Context, data []byte) (serde.Message, error) {
+	format := msgFormats.Get(ctx.GetFormat())
+
+	ctx = serde.WithFactory(ctx, LinkKey{}, fac.linkFac)
+
+	msg, err := format.Decode(ctx, data)
+	if err != nil {
+		return nil, xerrors.Errorf("decoding failed: %v", err)
+	}
+
+	return msg, nil
+}

--- a/core/ordering/cosipbft/fastsync/types/types_test.go
+++ b/core/ordering/cosipbft/fastsync/types/types_test.go
@@ -1,0 +1,90 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/core/validation/simple"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/testing/fake"
+)
+
+var testCalls = &fake.Call{}
+
+func init() {
+	RegisterMessageFormat(fake.GoodFormat,
+		fake.Format{Msg: CatchupMessage{}, Call: testCalls})
+	RegisterMessageFormat(fake.BadFormat, fake.NewBadFormat())
+}
+
+func TestRequestCatchupMessage_GetChain(t *testing.T) {
+	m := NewRequestCatchupMessage(1, 42)
+
+	require.Equal(t, uint64(42), m.GetLatest())
+	require.Equal(t, uint64(1), m.GetSplitMessageSize())
+}
+
+func TestRequestCatchupMessage_Serialize(t *testing.T) {
+	m := NewRequestCatchupMessage(1, 42)
+
+	data, err := m.Serialize(fake.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, fake.GetFakeFormatValue(), data)
+
+	_, err = m.Serialize(fake.NewBadContext())
+	require.EqualError(t, err, fake.Err("encoding failed"))
+}
+
+func TestCatchupMessage_GetBlockLinks(t *testing.T) {
+	m := NewCatchupMessage(false, makeChain(t, 0, 2))
+
+	require.Equal(t, 2, len(m.GetBlockLinks()))
+	require.Equal(t, false, m.GetSplitMessage())
+}
+
+func TestCatchupMessage_Serialize(t *testing.T) {
+	m := NewCatchupMessage(false, makeChain(t, 0, 2))
+
+	data, err := m.Serialize(fake.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, fake.GetFakeFormatValue(), data)
+
+	_, err = m.Serialize(fake.NewBadContext())
+	require.EqualError(t, err, fake.Err("encoding failed"))
+}
+
+func TestMessageFactory_Deserialize(t *testing.T) {
+	testCalls.Clear()
+
+	linkFac := types.NewLinkFactory(nil, nil, nil)
+
+	fac := NewMessageFactory(linkFac)
+
+	msg, err := fac.Deserialize(fake.NewContext(), nil)
+	require.NoError(t, err)
+	require.Equal(t, CatchupMessage{}, msg)
+
+	factory := testCalls.Get(0, 0).(serde.Context).GetFactory(LinkKey{})
+	require.NotNil(t, factory)
+
+	_, err = fac.Deserialize(fake.NewBadContext(), nil)
+	require.EqualError(t, err, fake.Err("decoding failed"))
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+func makeChain(t *testing.T, start, count uint64) []types.BlockLink {
+	blocks := make([]types.BlockLink, count)
+
+	for index := uint64(0); index < count; index++ {
+		block, err := types.NewBlock(simple.NewResult(nil), types.WithIndex(index))
+		require.NoError(t, err)
+
+		blocks[index-start], err = types.NewBlockLink(types.Digest{}, block)
+		require.NoError(t, err)
+	}
+
+	return blocks
+}

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -16,6 +16,7 @@ import (
 	"go.dedis.ch/dela/core/ordering/cosipbft/blockstore"
 	"go.dedis.ch/dela/core/ordering/cosipbft/blocksync"
 	"go.dedis.ch/dela/core/ordering/cosipbft/contracts/viewchange"
+	"go.dedis.ch/dela/core/ordering/cosipbft/fastsync"
 	"go.dedis.ch/dela/core/ordering/cosipbft/pbft"
 	"go.dedis.ch/dela/core/ordering/cosipbft/types"
 	"go.dedis.ch/dela/core/store"
@@ -28,6 +29,13 @@ import (
 	"golang.org/x/xerrors"
 )
 
+type syncMethodType bool
+
+const (
+	syncMethodFast  syncMethodType = false
+	syncMethodBlock syncMethodType = true
+)
+
 // Processor processes the messages to run a collective signing PBFT consensus.
 //
 // - implements cosi.Reactor
@@ -38,7 +46,8 @@ type processor struct {
 
 	logger      zerolog.Logger
 	pbftsm      pbft.StateMachine
-	sync        blocksync.Synchronizer
+	bsync       blocksync.Synchronizer
+	fsync       fastsync.Synchronizer
 	tree        blockstore.TreeCache
 	pool        pool.Pool
 	watcher     core.Observable
@@ -49,20 +58,32 @@ type processor struct {
 	context serde.Context
 	genesis blockstore.GenesisStore
 	blocks  blockstore.BlockStore
+	// catchup sends catchup requests to the players to get new blocks
+	catchup chan mino.Players
 
 	started chan struct{}
 }
 
 func newProcessor() *processor {
-	return &processor{
+	proc := &processor{
 		watcher: core.NewWatcher(),
 		context: json.NewContext(),
 		started: make(chan struct{}),
+		catchup: make(chan mino.Players),
 	}
+	go proc.catchupHandler()
+	return proc
+}
+
+func (h *processor) syncMethod() syncMethodType {
+	if h.bsync != nil {
+		return syncMethodBlock
+	}
+	return syncMethodFast
 }
 
 // Invoke implements cosi.Reactor. It processes the messages from the collective
-// signature module. The messages are either from the the prepare or the commit
+// signature module. The messages are either from the prepare or the commit
 // phase.
 func (h *processor) Invoke(from mino.Address, msg serde.Message) ([]byte, error) {
 	switch in := msg.(type) {
@@ -70,16 +91,39 @@ func (h *processor) Invoke(from mino.Address, msg serde.Message) ([]byte, error)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		blocks := h.blocks.Watch(ctx)
+		if h.syncMethod() == syncMethodFast {
+			// Check if a catchup is needed for fastsync
+			var roster mino.Players
+			if h.blocks.Len() == 0 && in.GetBlock().GetIndex() > 0 {
+				h.logger.Info().Msgf("node joined an existing blockchain from %+v", from)
+				roster = mino.NewAddresses(from)
+			} else if in.GetBlock().GetIndex() > h.blocks.Len() {
+				h.logger.Warn().Msgf("node got asked to sign block-index %d, "+
+					"but has only %d blocks", in.GetBlock().GetIndex(),
+					h.blocks.Len())
+				var err error
+				roster, err = h.getCurrentRoster()
+				if err != nil {
+					return nil, xerrors.Errorf("failed to get roster: %v", err)
+				}
+			}
 
-		// In case the node is falling behind the chain, it gives it a chance to
-		// catch up before moving forward.
-		latest := h.sync.GetLatest()
+			if roster != nil {
+				h.catchup <- roster
+				return nil, xerrors.Errorf("needed to catch up")
+			}
+		} else {
+			blocks := h.blocks.Watch(ctx)
 
-		if latest > h.blocks.Len() {
-			for link := range blocks {
-				if link.GetBlock().GetIndex() >= latest {
-					cancel()
+			// In case the node is falling behind the chain, it gives it a chance to
+			// catch up before moving forward.
+			latest := h.bsync.GetLatest()
+
+			if latest > h.blocks.Len() {
+				for link := range blocks {
+					if link.GetBlock().GetIndex() >= latest {
+						cancel()
+					}
 				}
 			}
 		}
@@ -144,9 +188,14 @@ func (h *processor) Process(req mino.Request) (serde.Message, error) {
 
 		return nil, h.storeGenesis(msg.GetGenesis().GetRoster(), &root)
 	case types.DoneMessage:
-		err := h.pbftsm.Finalize(msg.GetID(), msg.GetSignature())
-		if err != nil {
-			return nil, xerrors.Errorf("pbftsm finalized failed: %v", err)
+		if h.pbftsm.GetState() == pbft.InitialState {
+			h.logger.Warn().Msgf("Got block without commit from %v - catching up", req.Address)
+			h.catchup <- mino.NewAddresses(req.Address)
+		} else {
+			err := h.pbftsm.Finalize(msg.GetID(), msg.GetSignature())
+			if err != nil {
+				return nil, xerrors.Errorf("pbftsm finalized failed: %v", err)
+			}
 		}
 	case types.ViewMessage:
 		param := pbft.ViewParam{
@@ -249,4 +298,21 @@ func (h *processor) makeAccess(store store.Snapshot, roster authority.Authority)
 	}
 
 	return nil
+}
+
+// catchupHandler listens to incoming requests for potentially missing blocks.
+// It is started as a go-routine
+func (h *processor) catchupHandler() {
+	for players := range h.catchup {
+		if h.syncMethod() == syncMethodFast {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := h.fsync.Sync(ctx, players,
+				fastsync.Config{SplitMessageSize: DefaultFastSyncMessageSize})
+			if err != nil {
+				h.logger.Err(err)
+			}
+			cancel()
+		}
+	}
+	panic("catchup channel got closed - this should not happen")
 }

--- a/core/ordering/cosipbft/proc_test.go
+++ b/core/ordering/cosipbft/proc_test.go
@@ -24,7 +24,7 @@ func TestProcessor_BlockMessage_Invoke(t *testing.T) {
 
 	proc := newProcessor()
 	proc.rosterFac = authority.NewFactory(fake.AddressFactory{}, fake.PublicKeyFactory{})
-	proc.sync = fakeSync{latest: 1}
+	proc.bsync = fakeSync{latest: 1}
 	proc.blocks = fakeStore{}
 	proc.pbftsm = fakeSM{
 		state: pbft.InitialState,

--- a/mino/minoch/mod.go
+++ b/mino/minoch/mod.go
@@ -10,7 +10,6 @@
 // instance should drop the message.
 //
 // Documentation Last Review: 06.10.2020
-//
 package minoch
 
 import (
@@ -85,7 +84,7 @@ func (m *Minoch) GetAddress() mino.Address {
 	return address{id: m.identifier}
 }
 
-// AddFilter adds the filter to all of the RPCs. This must be called before
+// AddFilter adds the filter to all the RPCs. This must be called before
 // receiving requests.
 func (m *Minoch) AddFilter(filter Filter) {
 	m.filters = append(m.filters, filter)

--- a/mino/minoch/rpc.go
+++ b/mino/minoch/rpc.go
@@ -211,7 +211,7 @@ func (c RPC) Stream(ctx context.Context, memship mino.Players) (mino.Sender, min
 			case env := <-in:
 				for _, to := range env.to {
 					output := orchRecv.out
-					if !to.(address).orchestrator {
+					if !to.(address).orchestrator || !to.Equal(orchAddr) {
 						output = outs[to.String()].out
 					}
 

--- a/mino/option.go
+++ b/mino/option.go
@@ -5,6 +5,7 @@
 package mino
 
 import (
+	"math/rand"
 	"sort"
 )
 
@@ -68,6 +69,19 @@ func IndexFilter(index int) FilterUpdater {
 	}
 }
 
+// RejectFilter removes the given index
+func RejectFilter(index int) FilterUpdater {
+	return func(filters *Filter) {
+		arr := filters.Indices
+		i := sort.IntSlice(arr).Search(index)
+		// do nothing if the element is not there
+		if i == len(arr) || arr[i] != index {
+			return
+		}
+		filters.Indices = append(filters.Indices[0:i], filters.Indices[i+1:]...)
+	}
+}
+
 // RangeFilter is a filter to include a range of indices.
 func RangeFilter(start, end int) FilterUpdater {
 	return func(filters *Filter) {
@@ -93,5 +107,20 @@ func RangeFilter(start, end int) FilterUpdater {
 func ListFilter(indices []int) FilterUpdater {
 	return func(filters *Filter) {
 		filters.Indices = indices
+	}
+}
+
+// RandomFilter shuffles the elements of the Index and then limits the size
+// of Indices to 'count'.
+// If there are less than 'count' elements, only the shuffling takes place.
+func RandomFilter(count int) FilterUpdater {
+	return func(filters *Filter) {
+		rand.Shuffle(len(filters.Indices),
+			func(i, j int) {
+				filters.Indices[i], filters.Indices[j] = filters.Indices[j], filters.Indices[i]
+			})
+		if len(filters.Indices) > count {
+			filters.Indices = filters.Indices[:count]
+		}
 	}
 }

--- a/mino/option_test.go
+++ b/mino/option_test.go
@@ -33,20 +33,38 @@ func TestFilter_RotateFilter(t *testing.T) {
 
 func TestFilter_IndexFilter(t *testing.T) {
 	filters := &Filter{Indices: []int{}}
-
 	IndexFilter(1)(filters)
-	require.Equal(t, filters.Indices, []int{1})
+	require.Equal(t, []int{1}, filters.Indices)
 
 	IndexFilter(2)(filters)
-	require.Equal(t, filters.Indices, []int{1, 2})
+	require.Equal(t, []int{1, 2}, filters.Indices)
 
-	IndexFilter(0)(filters)
-	require.Equal(t, filters.Indices, []int{0, 1, 2})
-
-	IndexFilter(0)(filters)
-	IndexFilter(1)(filters)
 	IndexFilter(2)(filters)
-	require.Equal(t, filters.Indices, []int{0, 1, 2})
+	require.Equal(t, []int{1, 2}, filters.Indices)
+
+	IndexFilter(0)(filters)
+	require.Equal(t, []int{0, 1, 2}, filters.Indices)
+}
+
+func TestFilter_RejectFilter(t *testing.T) {
+	filters := &Filter{Indices: []int{1, 2, 3, 4}}
+
+	testCases := []struct {
+		filterVal int
+		expected  []int
+	}{
+		{0, []int{1, 2, 3, 4}},
+		{5, []int{1, 2, 3, 4}},
+		{2, []int{1, 3, 4}},
+		{1, []int{3, 4}},
+		{4, []int{3}},
+		{3, []int{}},
+	}
+
+	for _, tc := range testCases {
+		RejectFilter(tc.filterVal)(filters)
+		require.Equal(t, tc.expected, filters.Indices)
+	}
 }
 
 func TestFilter_RangeFilter(t *testing.T) {

--- a/serde/json/json.go
+++ b/serde/json/json.go
@@ -11,6 +11,7 @@ import (
 	_ "go.dedis.ch/dela/core/access/darc/json"
 	_ "go.dedis.ch/dela/core/ordering/cosipbft/authority/json"
 	_ "go.dedis.ch/dela/core/ordering/cosipbft/blocksync/json"
+	_ "go.dedis.ch/dela/core/ordering/cosipbft/fastsync/json"
 	_ "go.dedis.ch/dela/core/ordering/cosipbft/json"
 	_ "go.dedis.ch/dela/core/txn/signed/json"
 	_ "go.dedis.ch/dela/core/validation/simple/json"


### PR DESCRIPTION
This PR adds a faster synchronisation protocol which only gets called if a node
thinks it's out of sync with the rest of the chain.
The messages passed back and forth are kept minimal to avoid using too much bandwidth.
The cosipbft can now be run either with the old blocksync, or using fastsync.

For reviewing, please:
- check that comments are understandable
- have a good look at `core/ordering/cosipbft/fastsync/*.go` - sub-directories `types` and `json` less important
- verify the changes in `core/ordering/cosipbft/*.go` are reasonable

This has been tested with the voting benchmark and shows great promise: 700ms for the 1000th cast, instead of 5.5s with the old blocksync!

Closes https://github.com/c4dt/d-voting/issues/54