### PR TITLE
Don't use the sync beforehand - the manager.Make takes care of that

### DIFF
--- a/core/txn/pool/controller/action.go
+++ b/core/txn/pool/controller/action.go
@@ -62,11 +62,6 @@ func (a *addAction) Execute(ctx node.Context) error {
 
 	manager := getManager(signer, a.client)
 
-	err = manager.Sync()
-	if err != nil {
-		return xerrors.Errorf("failed to sync manager: %v", err)
-	}
-
 	tx, err := manager.Make(args...)
 	if err != nil {
 		return xerrors.Errorf("creating transaction: %v", err)

--- a/core/txn/pool/controller/action_test.go
+++ b/core/txn/pool/controller/action_test.go
@@ -49,18 +49,11 @@ func TestExecute(t *testing.T) {
 	require.EqualError(t, err, "failed to include tx: "+fake.Err("failed to add"))
 
 	getManager = func(c crypto.Signer, s signed.Client) txn.Manager {
-		return badManager{}
-	}
-
-	err = action.Execute(ctx)
-	require.EqualError(t, err, "creating transaction: "+fake.Err("make fail"))
-
-	getManager = func(c crypto.Signer, s signed.Client) txn.Manager {
 		return badManager{failSync: true}
 	}
 
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "failed to sync manager: "+fake.Err("sync fail"))
+	require.EqualError(t, err, "creating transaction: "+fake.Err("make fail"))
 
 	err = os.WriteFile(keyFile, []byte("bad signer"), os.ModePerm)
 	require.NoError(t, err)

--- a/core/txn/pool/controller/controller.go
+++ b/core/txn/pool/controller/controller.go
@@ -63,7 +63,7 @@ func (miniController) OnStop(inj node.Injector) error {
 	return nil
 }
 
-// client return monotically increasing nonce
+// client returns monotonically increasing nonce
 //
 // - implements signed.Client
 type client struct {


### PR DESCRIPTION
As the pool manager is a very simple nonce-manager which just increases the nonce by 1 every time the `Sync` is called, multiple calls to `Sync` make the system fail.