### PR TITLE
Check the source repo of the PR and not the destination repo

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{matrix.platform}}
     env:
       LLVL: trace
-      coverage: ${{ matrix.platform == 'ubuntu-latest' && github.repository == 'dedis/dela' }}
+      coverage: ${{ matrix.platform == 'ubuntu-latest' && secrets.SONAR_TOKEN != '' }}
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4


### PR DESCRIPTION
Tested it against the dedis/dela, and this time it correctly doesn't `test_coverage`, but only `test`. I couldn't test it on dedis' repo, but let's hope this one works, too :)